### PR TITLE
Support for non-Arduino build for the core SCAMP encode/decode

### DIFF
--- a/Code/RFBitBanger/NonArduino.h
+++ b/Code/RFBitBanger/NonArduino.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Daniel Marks
+ * Copyright (c) 2023 Daniel Marks
 
 This software is provided 'as-is', without any express or implied
 warranty. In no event will the authors be held liable for any damages
@@ -23,8 +23,8 @@ This header file provides some definitions needed when building
 the code outside of the Arduino environment.  IT IS NOT USED IN NORMAL
 RFBITBANGER OPERATION.
  */
-#ifndef __NONAARDUINO__
-#define __NONAARDUINO__
+#ifndef _NONARDUINO_H
+#define _NONARDUINO_H
 
 #include <stdint.h>
 #include <stddef.h>

--- a/Code/RFBitBanger/NonArduino.h
+++ b/Code/RFBitBanger/NonArduino.h
@@ -29,19 +29,22 @@ RFBITBANGER OPERATION.
 #include <stdint.h>
 #include <stddef.h>
 
-// Ignore this directive completely
+// This is an AVR-specific function that allows you to store data in flash 
+// (program) memory instead of SRAM.
+// Ignore this directive completely.
 #define PROGMEM
 
+// Used to read from the program memory
 #define pgm_read_byte_near(addr) (pgm_read_byte_near_2((const uint8_t*)addr))
 #define pgm_read_word_near(addr) (pgm_read_word_near_2((const uint16_t*)addr))
 
 uint8_t pgm_read_byte_near_2(const uint8_t* addr);
 uint16_t pgm_read_word_near_2(const uint16_t* addr);
 
+// Arduino platform
 unsigned long millis();
 void cli();
 void sei();
-void* memset(void* dest, int c, size_t count);
 
 // This is defined in RFBitBanger.ino
 void received_character(uint8_t ch);

--- a/Code/RFBitBanger/NonArduino.h
+++ b/Code/RFBitBanger/NonArduino.h
@@ -19,16 +19,17 @@ freely, subject to the following restrictions:
  */
 
 /*
-This header file is used to provide some definitions needed when building
-the code outside of the Arduino environment.  
+This header file provides some definitions needed when building
+the code outside of the Arduino environment.  IT IS NOT USED IN NORMAL
+RFBITBANGER OPERATION.
  */
-#ifndef _NonArduino_h
-#define _NonArduino_h
+#ifndef __NONAARDUINO__
+#define __NONAARDUINO__
 
 #include <stdint.h>
 #include <stddef.h>
 
-// Ignore this directive
+// Ignore this directive completely
 #define PROGMEM
 
 #define pgm_read_byte_near(addr) (pgm_read_byte_near_2((const uint8_t*)addr))
@@ -42,7 +43,7 @@ void cli();
 void sei();
 void* memset(void* dest, int c, size_t count);
 
-// This is defined in RFBitBanger.io
+// This is defined in RFBitBanger.ino
 void received_character(uint8_t ch);
 
 #endif

--- a/Code/RFBitBanger/NonArduino.h
+++ b/Code/RFBitBanger/NonArduino.h
@@ -1,5 +1,3 @@
-/*  golay.h */
-
 /*
  * Copyright (c) 2021 Daniel Marks
 
@@ -20,16 +18,31 @@ freely, subject to the following restrictions:
 3. This notice may not be removed or altered from any source distribution.
  */
 
-#ifndef __GOLAY_H
-#define __GOLAY_H
+/*
+This header file is used to provide some definitions needed when building
+the code outside of the Arduino environment.  
+ */
+#ifndef _NonArduino_h
+#define _NonArduino_h
 
 #include <stdint.h>
+#include <stddef.h>
 
-uint32_t golay_encode(uint16_t wd_enc);
-uint16_t golay_decode(uint32_t codeword, uint8_t *biterrs);
+// Ignore this directive
+#define PROGMEM
 
-#ifdef __cplusplus
-}
+#define pgm_read_byte_near(addr) (pgm_read_byte_near_2((const uint8_t*)addr))
+#define pgm_read_word_near(addr) (pgm_read_word_near_2((const uint16_t*)addr))
+
+uint8_t pgm_read_byte_near_2(const uint8_t* addr);
+uint16_t pgm_read_word_near_2(const uint16_t* addr);
+
+unsigned long millis();
+void cli();
+void sei();
+void* memset(void* dest, int c, size_t count);
+
+// This is defined in RFBitBanger.io
+void received_character(uint8_t ch);
+
 #endif
-
-#endif /* __GOLAY_H */

--- a/Code/RFBitBanger/dspint.c
+++ b/Code/RFBitBanger/dspint.c
@@ -25,6 +25,8 @@ freely, subject to the following restrictions:
 
 #ifdef ARDUINO
 #include <Arduino.h>
+#else 
+#include "NonArduino.h"
 #endif
 
 #ifdef DSPINT_DEBUG
@@ -45,6 +47,7 @@ protocol_state  ps;
 uint8_t decode_insert_into_fifo(uint8_t c)
 {
   received_character(c);
+  return 0;
 }
 
 #if 0
@@ -202,7 +205,7 @@ void dsp_initialize_rtty(uint8_t protocol, uint8_t wide)
     df.dfo = rtty_frequency_offset;
 }
 
-void dsp_initialize_ssb(protocol)
+void dsp_initialize_ssb(uint8_t protocol)
 {
     dsp_initialize_fastscan();
     df.dfo = ssb_frequency_offset;

--- a/Code/RFBitBanger/dspint.c
+++ b/Code/RFBitBanger/dspint.c
@@ -26,6 +26,7 @@ freely, subject to the following restrictions:
 #ifdef ARDUINO
 #include <Arduino.h>
 #else 
+#include <string.h>
 #include "NonArduino.h"
 #endif
 

--- a/Code/RFBitBanger/dspint.h
+++ b/Code/RFBitBanger/dspint.h
@@ -91,7 +91,7 @@ typedef void (*dsp_dispatch_callback)(struct _dsp_txmit_message_state *);
 
 typedef void (*dsp_interrupt_routine)(void);
 typedef void (*dsp_decode_process)(void);
-typedef void (*dsp_xmit_routine)(dsp_txmit_message_state *, dsp_dispatch_callback);
+typedef uint8_t (*dsp_xmit_routine)(dsp_txmit_message_state *, dsp_dispatch_callback);
 typedef int16_t (*dsp_frequency_offset)(void);
 
 /* this is stuff that is initialized when the modulation mode

--- a/Code/RFBitBanger/golay.c
+++ b/Code/RFBitBanger/golay.c
@@ -23,8 +23,11 @@ freely, subject to the following restrictions:
 
 #ifdef ARDUINO
 #include <Arduino.h>
+#else
+#include "NonArduino.h"
 #endif
 
+#include "dspint.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/Code/RFBitBanger/scamp.c
+++ b/Code/RFBitBanger/scamp.c
@@ -32,6 +32,8 @@ freely, subject to the following restrictions:
 
 #ifdef ARDUINO
 #include <Arduino.h>
+#else
+#include "NonArduino.h"
 #endif
 
 #ifdef SCAMP_DEBUG
@@ -454,6 +456,7 @@ uint8_t scamp_txmit(dsp_txmit_message_state *dtms, dsp_dispatch_callback ddc)
   transmit_set(0);
   muteaudio_set(0);
   ps.ss.reset_protocol = 1;
+  return 0;
 }
 
 void scamp_reset_codeword(void)

--- a/Code/RFBitBanger/scamp.h
+++ b/Code/RFBitBanger/scamp.h
@@ -24,6 +24,8 @@ freely, subject to the following restrictions:
 #ifndef __SCAMP_H
 #define __SCAMP_H
 
+#include "dspint.h"
+
 #define SCAMP_VERSION_NO "0.91"
 
 #ifdef __cplusplus
@@ -133,6 +135,7 @@ uint8_t scamp_txmit(dsp_txmit_message_state *dtms, dsp_dispatch_callback ddc);
 void scamp_new_sample(void);
 void scamp_decode_process(void);
 uint8_t hamming_weight_16(uint16_t n);
+void scamp_reset_codeword(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The goal here is to be able to build versions of the SCAMP terminal without a dependency on the Arduino ecosystem. This will enable the use of other microcontrollers. 

Changes

- Added NonArduino.h header file to provide definitions for things that would normally come in via the Arduino environment. The alternate environment will need to provide implementations for these things.
- Added some includes to resolve errors with forward references.
- Cleaned up a few minor compiler warnings.

At this point scamp.c, golay.c, and dspint.c compile without warnings outside of Arduino using a recent gcc (Clang 15.0.0).
